### PR TITLE
feat: add Docker Hub support with dual registry publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,18 +4,47 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
 
 env:
   REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
   IMAGE_NAME: cronschedules/cronjob-scale-down-operator
-  IMAGE_TAG: 0.1.0
 
 jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Get the version
+        id: get_version
+        run: |
+          VERSION=$(cat VERSION)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Build Docker image (no push)
+        run: |
+          make docker-build
+        env:
+          IMAGE_TAG: ${{ steps.get_version.outputs.version }}
+
   build-and-push:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
@@ -30,17 +59,27 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       
       - name: Get the version
+        id: get_version_push
         run: |
-          echo "VERSION=$(cat VERSION)" >> $GITHUB_ENV
+          VERSION=$(cat VERSION)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image to both registries
         run: |
           make docker-build
-          make docker-push
+          make docker-push-all
         env:
-          IMAGE_TAG: ${{ env.VERSION }}
+          IMAGE_TAG: ${{ steps.get_version_push.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,27 @@
-name: Create Release
+name: Create Release and Push Multi-Arch Images
 
 on:
   push:
     branches:
       - main
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag'
+        required: true
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
+  IMAGE_NAME: cronschedules/cronjob-scale-down-operator
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
     
@@ -31,9 +45,74 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
-          name: Release ${{ env.VERSION }}
-          tag_name: v${{ env.VERSION }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          tag_name: v${{ steps.get_version.outputs.version }}
           draft: false
           prerelease: false
           generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-push-multiarch:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Get release tag
+        id: get_tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG=${GITHUB_REF#refs/tags/}
+            echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+          else
+            TAG="${{ github.event.inputs.tag }}"
+            echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Build and push multi-arch Docker images
+        run: |
+          make docker-buildx-all
+        env:
+          IMAGE_TAG: ${{ steps.get_tag.outputs.tag }}
+          PLATFORMS: linux/amd64,linux/arm64
+
+      - name: Update latest tags for releases
+        if: github.event_name == 'release'
+        run: |
+          # Tag and push latest to both registries
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.get_tag.outputs.tag }}
+          
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.get_tag.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -59,14 +59,17 @@ A Kubernetes operator that automatically scales down Deployments and StatefulSet
 
 #### Option 2: Using Container Image
 
-The operator is available as a pre-built container image:
+The operator is available as a pre-built container image from multiple registries:
 
 ```bash
-# Image available at:
-docker pull ghcr.io/z4ck404/cronjob-scale-down-operator:0.1.2
+# From Docker Hub:
+docker pull cronschedules/cronjob-scale-down-operator:0.3.0
+
+# From GitHub Container Registry:
+docker pull ghcr.io/cronschedules/cronjob-scale-down-operator:0.3.0
 ```
 
-Use this image in your custom deployments or with the provided Helm chart.
+Use these images in your custom deployments or with the provided Helm chart.
 
 #### Option 3: Using kubectl
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/z4ck404/cronjob-scale-down-operator
+  newName: ghcr.io/cronschedules/cronjob-scale-down-operator
   newTag: latest

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -399,7 +399,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: ghcr.io/z4ck404/cronjob-scale-down-operator:latest
+        image: ghcr.io/cronschedules/cronjob-scale-down-operator:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/README.md
+++ b/docs/README.md
@@ -164,14 +164,17 @@ helm install cronjob-scale-down-operator cronschedules/cronjob-scale-down-operat
 
 #### Option 2: Using Container Image
 
-The operator is available as a pre-built container image:
+The operator is available as a pre-built container image from multiple registries:
 
 ```bash
-# Image available at:
-docker pull ghcr.io/z4ck404/cronjob-scale-down-operator:0.3.0
+# From Docker Hub:
+docker pull cronschedules/cronjob-scale-down-operator:0.3.0
+
+# From GitHub Container Registry:
+docker pull ghcr.io/cronschedules/cronjob-scale-down-operator:0.3.0
 ```
 
-Use this image in your custom deployments or with the provided Helm chart.
+Use these images in your custom deployments or with the provided Helm chart.
 
 #### Option 3: Using kubectl
 
@@ -350,7 +353,7 @@ The operator can be installed using Helm for easier management and configuration
 
 ### Chart Information
 
-- **Repository**: `ghcr.io/z4ck404/cronjob-scale-down-operator`
+- **Repository**: `ghcr.io/cronschedules/cronjob-scale-down-operator` or `cronschedules/cronjob-scale-down-operator` (Docker Hub)
 - **Image Tag**: `0.3.0`
 - **Chart Version**: `0.3.0`
 
@@ -387,7 +390,7 @@ Key Helm chart values:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.repository` | Container image repository | `ghcr.io/z4ck404/cronjob-scale-down-operator` |
+| `image.repository` | Container image repository | `ghcr.io/cronschedules/cronjob-scale-down-operator` |
 | `image.tag` | Container image tag | `0.3.0` |
 | `replicaCount` | Number of operator replicas | `1` |
 | `resources.limits.memory` | Memory limit | `128Mi` |

--- a/docs/helm-installation.md
+++ b/docs/helm-installation.md
@@ -18,6 +18,10 @@ helm repo update
 # Install
 helm install cronjob-scale-down-operator cronschedules/cronjob-scale-down-operator
 
+# Or install with Docker Hub image
+helm install cronjob-scale-down-operator cronschedules/cronjob-scale-down-operator \
+  --set image.repository=cronschedules/cronjob-scale-down-operator
+
 # Verify
 kubectl get pods -l app.kubernetes.io/name=cronjob-scale-down-operator
 kubectl get crd cronjobscaledowns.cronschedules.elbazi.co
@@ -167,7 +171,7 @@ helm install cronjob-scale-down-operator cronschedules/cronjob-scale-down-operat
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.repository` | Container image repository | `ghcr.io/z4ck404/cronjob-scale-down-operator` |
+| `image.repository` | Container image repository | `ghcr.io/cronschedules/cronjob-scale-down-operator` |
 | `image.tag` | Container image tag | `0.3.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount` | Number of operator replicas | `1` |


### PR DESCRIPTION
🐳 Add Docker Hub publishing support alongside GitHub Container Registry

## Changes Made:

### Makefile Enhancements:
- Add Docker Hub registry configuration (DOCKERHUB_REGISTRY, DOCKERHUB_IMAGE_NAME)
- New targets: docker-push-dockerhub, docker-push-all, docker-buildx-dockerhub, docker-buildx-all
- Support for pushing to both registries simultaneously

### GitHub Actions Updates:
- build.yaml: Add Docker Hub login and dual registry publishing
- release.yaml: Enhanced with multi-arch builds for both registries
- Separate jobs for PRs (build-only) vs main pushes (build+push)
- Auto-create 'latest' tags on releases for both registries